### PR TITLE
fix: sort final results by score

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,5 +98,6 @@ func search(query string) []*turtle.Emoji {
 	}
 
 	consolidated := lo.Uniq(lo.Flatten(results))
+	sort.Stable(scoring.SortedByScoreDsc{Query: query, Emojis: &consolidated})
 	return consolidated
 }


### PR DESCRIPTION
When invoking the picker and entering "pray", I wanted the first result to be 🙏 but 📿 was the first result.  There was already nickname support in the scoring flow but the way the results were being combined `nameSlugMatches` always won over `keywordMatches`

Do a final sort by score before returning the consolidated results.  Your mileage may vary. 