### PR TITLE
Add frequently used emoji support and version workflow config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ main_amd64
 main_arm64
 scripts/*.egg-info/
 scripts/build/
+.gocache

--- a/README.md
+++ b/README.md
@@ -30,15 +30,8 @@ The binary now supports a small local usage database in Alfred's workflow data d
 
 - Empty query shows only emoji the user has actually selected before.
 - The amount shown on empty query is controlled by the Alfred variable `frequent_emoji_limit`.
-- Matching results use usage frequency as a tiebreaker, so your go-to emoji gradually bubble up.
-
-To persist usage counts, call the workflow binary once when the user selects an emoji:
-
-```shell
-./alfred-emoji-picker --record "{query}"
-```
-
-In Alfred, wire this as a separate `Run Script` / `External Trigger` step before the existing paste/copy action, and pass the selected emoji character as `{query}`.
+- When the query is empty, previously selected emoji are ordered by usage count.
+- You can reset the stored history with `./alfred-emoji-picker --reset-frequent`.
 
 # Update emojis
 
@@ -61,5 +54,4 @@ In Alfred, wire this as a separate `Run Script` / `External Trigger` step before
 - [x] Add scoring on results (exact match > partial match at beginning > partial match > keywords, categories, etc…)
 - [x] Add scripts to update the emoji database
 - [x] Support for auto-updates
-- [ ] Add content for the "About this Workflow" tab in the config builder
 - [ ] Support for skin tones (note: `Turtle` doesn't support them)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ go install
 
 Copy the executable in the Alfred workflow directory and export the new workflow from Alfred.
 
+# Frequently used emoji
+
+The binary now supports a small local usage database in Alfred's workflow data directory:
+
+- Empty query shows only emoji the user has actually selected before.
+- The amount shown on empty query is controlled by the Alfred variable `frequent_emoji_limit`.
+- Matching results use usage frequency as a tiebreaker, so your go-to emoji gradually bubble up.
+
+To persist usage counts, call the workflow binary once when the user selects an emoji:
+
+```shell
+./alfred-emoji-picker --record "{query}"
+```
+
+In Alfred, wire this as a separate `Run Script` / `External Trigger` step before the existing paste/copy action, and pass the selected emoji character as `{query}`.
+
 # Update emojis
 
 1) Emoji metadata (names, slugs, keywords) lives in the [`turtle`](https://github.com/devnoname120/turtle) module. Check the README on how to regenerate `emojis.go` to make it up-to-date, and push a new tag.
@@ -40,8 +56,10 @@ Copy the executable in the Alfred workflow directory and export the new workflow
 # TODO
 
 - [x] Restore clipboard after pasting emoji
+- [x] Support frequently used emoji
 - [ ] Support for multiple words fuzzy search
 - [x] Add scoring on results (exact match > partial match at beginning > partial match > keywords, categories, etc…)
 - [x] Add scripts to update the emoji database
 - [x] Support for auto-updates
+- [ ] Add content for the "About this Workflow" tab in the config builder
 - [ ] Support for skin tones (note: `Turtle` doesn't support them)

--- a/info.plist
+++ b/info.plist
@@ -1,0 +1,560 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>bundleid</key>
+	<string>com.github.devnoname120.alfred-emoji-picker</string>
+	<key>connections</key>
+	<dict>
+		<key>5514CC1D-FA62-4C53-ADC8-0A7E47EABE32</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>753EE7F7-6A84-4B07-9C48-1B53B2DBD393</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>715587DB-6FBB-4B61-A1E1-5DEC6AE8D9DE</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>2D22B761-F834-4061-8D65-4F6B2A0E2365</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>8E260531-B940-414D-8222-8F44CC4B8419</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>753EE7F7-6A84-4B07-9C48-1B53B2DBD393</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>715587DB-6FBB-4B61-A1E1-5DEC6AE8D9DE</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>85D92F9D-5FB7-43BB-972E-AA37378048E7</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>5514CC1D-FA62-4C53-ADC8-0A7E47EABE32</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</string>
+				<key>modifiers</key>
+				<integer>1048576</integer>
+				<key>modifiersubtext</key>
+				<string>Copy "{query}" into frontmost applicationto the clipboard</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>8D669A41-E6BD-402D-82CF-16D7788A3E14</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>D8F2C967-FA1A-4457-8373-998014ABC3A0</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>2D22B761-F834-4061-8D65-4F6B2A0E2365</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>8E260531-B940-414D-8222-8F44CC4B8419</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>D8F2C967-FA1A-4457-8373-998014ABC3A0</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>5514CC1D-FA62-4C53-ADC8-0A7E47EABE32</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</string>
+				<key>modifiers</key>
+				<integer>1048576</integer>
+				<key>modifiersubtext</key>
+				<string>Copy "{query}" into frontmost applicationto the clipboard</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+	</dict>
+	<key>createdby</key>
+	<string>devnoname120</string>
+	<key>description</key>
+	<string>Pick emojis within Alfred — at a blazing-fast speed</string>
+	<key>disabled</key>
+	<false/>
+	<key>name</key>
+	<string>Emoji picker</string>
+	<key>objects</key>
+	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>./alfred-emoji-picker --record "{query}"</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>2D22B761-F834-4061-8D65-4F6B2A0E2365</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<false/>
+				<key>clipboardtext</key>
+				<string>{clipboard:0}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>715587DB-6FBB-4B61-A1E1-5DEC6AE8D9DE</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<true/>
+				<key>clipboardtext</key>
+				<string>{query}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>5514CC1D-FA62-4C53-ADC8-0A7E47EABE32</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>1</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>emoji</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string>Loading results...</string>
+				<key>script</key>
+				<string>query=$*
+xattr -rd com.apple.quarantine ./alfred-emoji-picker &gt;/dev/null 2&gt;&amp;1 || true
+./alfred-emoji-picker "$query"</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>Search emoji</string>
+				<key>type</key>
+				<integer>0</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>85D92F9D-5FB7-43BB-972E-AA37378048E7</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>seconds</key>
+				<string>0.3</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.delay</string>
+			<key>uid</key>
+			<string>753EE7F7-6A84-4B07-9C48-1B53B2DBD393</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string># Based On The OneUpdater workflow, but heavily simplified for github releases
+# https://github.com/vitorgalvao/alfred-workflows/tree/master/OneUpdater
+#
+# Simplification courtesy of jsumners
+
+# THESE VARIABLES MUST BE SET.
+readonly github_repo='devnoname120/alfred-emoji-picker'
+readonly frequency_check='1' # days
+
+# FROM HERE ON, CODE SHOULD BE LEFT UNTOUCHED!
+readonly info_plist='info.plist'
+
+function abort {
+  echo "${1}" &gt;&amp;2
+  exit 1
+}
+
+function notification {
+  osascript -e "display notification \"${1}\" with title \"${alfred_workflow_name}\" subtitle \"A new version is available\""
+}
+
+function fetch_remote_version {
+  curl --silent "https://api.github.com/repos/${github_repo}/releases/latest" | grep 'tag_name' | head -1 | sed -E 's/.*tag_name": "v?(.*)".*/\1/'
+}
+
+function fetch_download_url {
+  curl --silent "https://api.github.com/repos/${github_repo}/releases/latest" | grep 'browser_download_url.*\.alfredworkflow"' | head -1 | sed -E 's/.*browser_download_url": "(.*)".*/\1/'
+}
+
+function download_and_install {
+  readonly tmpfile="$(mktemp).alfredworkflow"
+  notification 'Downloading and installing…'
+  curl --silent --location --output "${tmpfile}" "${1}"
+  open "${tmpfile}"
+}
+
+# Local sanity checks
+[[ -n "${alfred_workflow_version}" ]] || abort "'alfred_workflow_version' must be set."
+[[ -n "${alfred_workflow_name}" ]] || abort "'alfred_workflow_name' must be set."
+[[ "${github_repo}" =~ ^.+\/.+$ ]] || abort "'github_repo' (${github_repo}) must be in the format 'username/repo'."
+[[ "${frequency_check}" =~ ^[0-9]+$ ]] || abort "'frequency_check' (${frequency_check}) must be a number."
+
+# Check for updates
+if [[ $(find "${info_plist}" -mtime +"${frequency_check}"d) ]]; then
+  if [[ "${alfred_workflow_version}" == "$(fetch_remote_version)" ]]; then
+    touch "${info_plist}" # Reset timer by touching local file
+    exit 0
+  fi
+
+  download_and_install "$(fetch_download_url)"
+fi</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>8E260531-B940-414D-8222-8F44CC4B8419</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>action</key>
+				<integer>0</integer>
+				<key>argument</key>
+				<integer>0</integer>
+				<key>focusedappvariable</key>
+				<false/>
+				<key>focusedappvariablename</key>
+				<string></string>
+				<key>hotkey</key>
+				<integer>49</integer>
+				<key>hotmod</key>
+				<integer>1310720</integer>
+				<key>hotstring</key>
+				<string>Space</string>
+				<key>leftcursor</key>
+				<false/>
+				<key>modsmode</key>
+				<integer>0</integer>
+				<key>relatedAppsMode</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.trigger.hotkey</string>
+			<key>uid</key>
+			<string>8D669A41-E6BD-402D-82CF-16D7788A3E14</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<false/>
+				<key>clipboardtext</key>
+				<string>{query}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttreatemptyqueryasnil</key>
+				<false/>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>1</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string>Loading results...</string>
+				<key>script</key>
+				<string>query=$*
+xattr -rd com.apple.quarantine ./alfred-emoji-picker &gt;/dev/null 2&gt;&amp;1 || true
+./alfred-emoji-picker "$query"</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>Search emoji</string>
+				<key>type</key>
+				<integer>0</integer>
+				<key>withspace</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>D8F2C967-FA1A-4457-8373-998014ABC3A0</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+	</array>
+	<key>readme</key>
+	<string></string>
+	<key>uidata</key>
+	<dict>
+		<key>2D22B761-F834-4061-8D65-4F6B2A0E2365</key>
+		<dict>
+			<key>xpos</key>
+			<real>975</real>
+			<key>ypos</key>
+			<real>95</real>
+		</dict>
+		<key>5514CC1D-FA62-4C53-ADC8-0A7E47EABE32</key>
+		<dict>
+			<key>note</key>
+			<string>Auto Paste</string>
+			<key>xpos</key>
+			<real>455</real>
+			<key>ypos</key>
+			<real>95</real>
+		</dict>
+		<key>715587DB-6FBB-4B61-A1E1-5DEC6AE8D9DE</key>
+		<dict>
+			<key>note</key>
+			<string>Restore clipboard</string>
+			<key>xpos</key>
+			<real>760</real>
+			<key>ypos</key>
+			<real>95</real>
+		</dict>
+		<key>753EE7F7-6A84-4B07-9C48-1B53B2DBD393</key>
+		<dict>
+			<key>note</key>
+			<string>Wait for previous action to finish pasting</string>
+			<key>xpos</key>
+			<real>650</real>
+			<key>ypos</key>
+			<real>125</real>
+		</dict>
+		<key>85D92F9D-5FB7-43BB-972E-AA37378048E7</key>
+		<dict>
+			<key>xpos</key>
+			<real>230</real>
+			<key>ypos</key>
+			<real>95</real>
+		</dict>
+		<key>8D669A41-E6BD-402D-82CF-16D7788A3E14</key>
+		<dict>
+			<key>xpos</key>
+			<real>30</real>
+			<key>ypos</key>
+			<real>320</real>
+		</dict>
+		<key>8E260531-B940-414D-8222-8F44CC4B8419</key>
+		<dict>
+			<key>note</key>
+			<string>Auto Update - remove to disable</string>
+			<key>xpos</key>
+			<real>975</real>
+			<key>ypos</key>
+			<real>320</real>
+		</dict>
+		<key>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</key>
+		<dict>
+			<key>note</key>
+			<string>Only copy to clipboard (default)</string>
+			<key>xpos</key>
+			<real>610</real>
+			<key>ypos</key>
+			<real>320</real>
+		</dict>
+		<key>D8F2C967-FA1A-4457-8373-998014ABC3A0</key>
+		<dict>
+			<key>xpos</key>
+			<real>230</real>
+			<key>ypos</key>
+			<real>320</real>
+		</dict>
+	</dict>
+	<key>userconfigurationconfig</key>
+	<array>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>defaultvalue</key>
+				<integer>20</integer>
+				<key>markercount</key>
+				<integer>11</integer>
+				<key>maxvalue</key>
+				<integer>100</integer>
+				<key>minvalue</key>
+				<integer>0</integer>
+				<key>onlystoponmarkers</key>
+				<false/>
+				<key>showmarkers</key>
+				<true/>
+			</dict>
+			<key>description</key>
+			<string>Maximum number of frequently used emoji to show when the query is empty. Set to 0 to disable.</string>
+			<key>label</key>
+			<string>Frequent Emoji Limit</string>
+			<key>type</key>
+			<string>slider</string>
+			<key>variable</key>
+			<string>frequent_emoji_limit</string>
+		</dict>
+	</array>
+	<key>version</key>
+	<string>1.6</string>
+	<key>webaddress</key>
+	<string>https://github.com/devnoname120/alfred-emoji-picker</string>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -6,6 +6,19 @@
 	<string>com.github.devnoname120.alfred-emoji-picker</string>
 	<key>connections</key>
 	<dict>
+		<key>3AF7AC2A-A976-48BF-BC47-85FFC9489A93</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>5514CC1D-FA62-4C53-ADC8-0A7E47EABE32</key>
 		<array>
 			<dict>
@@ -21,16 +34,6 @@
 		</array>
 		<key>715587DB-6FBB-4B61-A1E1-5DEC6AE8D9DE</key>
 		<array>
-			<dict>
-				<key>destinationuid</key>
-				<string>2D22B761-F834-4061-8D65-4F6B2A0E2365</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
 			<dict>
 				<key>destinationuid</key>
 				<string>8E260531-B940-414D-8222-8F44CC4B8419</string>
@@ -55,11 +58,11 @@
 				<false/>
 			</dict>
 		</array>
-		<key>85D92F9D-5FB7-43BB-972E-AA37378048E7</key>
+		<key>775BB19D-DB24-45D0-8B65-72BE256BE916</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>5514CC1D-FA62-4C53-ADC8-0A7E47EABE32</string>
+				<string>B9B62968-2D5A-448F-AFA4-55699A19A300</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -69,11 +72,36 @@
 			</dict>
 			<dict>
 				<key>destinationuid</key>
-				<string>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</string>
+				<string>B595CA76-8AE4-4B04-937A-6E3F9F77B39C</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>AAF09358-216D-49FD-B955-D0AD13BF137E</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>85D92F9D-5FB7-43BB-972E-AA37378048E7</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>775BB19D-DB24-45D0-8B65-72BE256BE916</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>AA873DB5-AD67-4276-AB8B-B7EF039B0D8B</string>
 				<key>modifiers</key>
 				<integer>1048576</integer>
 				<key>modifiersubtext</key>
-				<string>Copy "{query}" into frontmost applicationto the clipboard</string>
+				<string>Copy "{query}" to the clipboard</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -82,7 +110,7 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>D8F2C967-FA1A-4457-8373-998014ABC3A0</string>
+				<string>85D92F9D-5FB7-43BB-972E-AA37378048E7</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -95,16 +123,6 @@
 		<array>
 			<dict>
 				<key>destinationuid</key>
-				<string>2D22B761-F834-4061-8D65-4F6B2A0E2365</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-			<dict>
-				<key>destinationuid</key>
 				<string>8E260531-B940-414D-8222-8F44CC4B8419</string>
 				<key>modifiers</key>
 				<integer>0</integer>
@@ -114,7 +132,34 @@
 				<false/>
 			</dict>
 		</array>
-		<key>D8F2C967-FA1A-4457-8373-998014ABC3A0</key>
+		<key>AA873DB5-AD67-4276-AB8B-B7EF039B0D8B</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>B595CA76-8AE4-4B04-937A-6E3F9F77B39C</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>sourceoutputuid</key>
+				<string>AAF09358-216D-49FD-B955-D0AD13BF137E</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>3AF7AC2A-A976-48BF-BC47-85FFC9489A93</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>B595CA76-8AE4-4B04-937A-6E3F9F77B39C</key>
+		<array/>
+		<key>B9B62968-2D5A-448F-AFA4-55699A19A300</key>
 		<array>
 			<dict>
 				<key>destinationuid</key>
@@ -123,16 +168,6 @@
 				<integer>0</integer>
 				<key>modifiersubtext</key>
 				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-			<dict>
-				<key>destinationuid</key>
-				<string>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</string>
-				<key>modifiers</key>
-				<integer>1048576</integer>
-				<key>modifiersubtext</key>
-				<string>Copy "{query}" into frontmost applicationto the clipboard</string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -148,29 +183,6 @@
 	<string>Emoji picker</string>
 	<key>objects</key>
 	<array>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>concurrently</key>
-				<false/>
-				<key>escaping</key>
-				<integer>102</integer>
-				<key>script</key>
-				<string>./alfred-emoji-picker --record "{query}"</string>
-				<key>scriptargtype</key>
-				<integer>0</integer>
-				<key>scriptfile</key>
-				<string></string>
-				<key>type</key>
-				<integer>0</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.script</string>
-			<key>uid</key>
-			<string>2D22B761-F834-4061-8D65-4F6B2A0E2365</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
 		<dict>
 			<key>config</key>
 			<dict>
@@ -212,6 +224,132 @@
 		<dict>
 			<key>config</key>
 			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>query="$1"
+
+./alfred-emoji-picker --record "$query"
+
+echo -n "$query"</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>B9B62968-2D5A-448F-AFA4-55699A19A300</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>seconds</key>
+				<string>0.3</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.delay</string>
+			<key>uid</key>
+			<string>753EE7F7-6A84-4B07-9C48-1B53B2DBD393</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<true/>
+						<key>matchmode</key>
+						<integer>0</integer>
+						<key>matchstring</key>
+						<string>__reset_frequent__</string>
+						<key>outputlabel</key>
+						<string>Reset frequent</string>
+						<key>uid</key>
+						<string>AAF09358-216D-49FD-B955-D0AD13BF137E</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>else</string>
+				<key>hideelse</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.conditional</string>
+			<key>uid</key>
+			<string>775BB19D-DB24-45D0-8B65-72BE256BE916</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>action</key>
+				<integer>0</integer>
+				<key>argument</key>
+				<integer>0</integer>
+				<key>focusedappvariable</key>
+				<false/>
+				<key>focusedappvariablename</key>
+				<string></string>
+				<key>hotkey</key>
+				<integer>49</integer>
+				<key>hotmod</key>
+				<integer>1310720</integer>
+				<key>hotstring</key>
+				<string>Space</string>
+				<key>leftcursor</key>
+				<false/>
+				<key>modsmode</key>
+				<integer>0</integer>
+				<key>relatedAppsMode</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.trigger.hotkey</string>
+			<key>uid</key>
+			<string>8D669A41-E6BD-402D-82CF-16D7788A3E14</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>./alfred-emoji-picker --reset-frequent</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>B595CA76-8AE4-4B04-937A-6E3F9F77B39C</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
 				<key>alfredfiltersresults</key>
 				<false/>
 				<key>alfredfiltersresultsmatchmode</key>
@@ -237,9 +375,10 @@
 				<key>runningsubtext</key>
 				<string>Loading results...</string>
 				<key>script</key>
-				<string>query=$*
+				<string>query="$1"
 xattr -rd com.apple.quarantine ./alfred-emoji-picker &gt;/dev/null 2&gt;&amp;1 || true
-./alfred-emoji-picker "$query"</string>
+./alfred-emoji-picker "$query"
+</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>
@@ -263,15 +402,80 @@ xattr -rd com.apple.quarantine ./alfred-emoji-picker &gt;/dev/null 2&gt;&amp;1 |
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>seconds</key>
-				<string>0.3</string>
+				<key>conditions</key>
+				<array>
+					<dict>
+						<key>inputstring</key>
+						<string></string>
+						<key>matchcasesensitive</key>
+						<true/>
+						<key>matchmode</key>
+						<integer>0</integer>
+						<key>matchstring</key>
+						<string>__reset_frequent__</string>
+						<key>outputlabel</key>
+						<string>Reset frequent</string>
+						<key>uid</key>
+						<string>AAF09358-216D-49FD-B955-D0AD13BF137E</string>
+					</dict>
+				</array>
+				<key>elselabel</key>
+				<string>else</string>
+				<key>hideelse</key>
+				<false/>
 			</dict>
 			<key>type</key>
-			<string>alfred.workflow.utility.delay</string>
+			<string>alfred.workflow.utility.conditional</string>
 			<key>uid</key>
-			<string>753EE7F7-6A84-4B07-9C48-1B53B2DBD393</string>
+			<string>AA873DB5-AD67-4276-AB8B-B7EF039B0D8B</string>
 			<key>version</key>
 			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>autopaste</key>
+				<false/>
+				<key>clipboardtext</key>
+				<string>{query}</string>
+				<key>ignoredynamicplaceholders</key>
+				<false/>
+				<key>transient</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.output.clipboard</string>
+			<key>uid</key>
+			<string>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</string>
+			<key>version</key>
+			<integer>3</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
+				<string>query="$1"
+
+./alfred-emoji-picker --record "$query"
+
+echo -n "$query"</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>3AF7AC2A-A976-48BF-BC47-85FFC9489A93</string>
+			<key>version</key>
+			<integer>2</integer>
 		</dict>
 		<dict>
 			<key>config</key>
@@ -346,182 +550,146 @@ fi</string>
 			<key>version</key>
 			<integer>2</integer>
 		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>action</key>
-				<integer>0</integer>
-				<key>argument</key>
-				<integer>0</integer>
-				<key>focusedappvariable</key>
-				<false/>
-				<key>focusedappvariablename</key>
-				<string></string>
-				<key>hotkey</key>
-				<integer>49</integer>
-				<key>hotmod</key>
-				<integer>1310720</integer>
-				<key>hotstring</key>
-				<string>Space</string>
-				<key>leftcursor</key>
-				<false/>
-				<key>modsmode</key>
-				<integer>0</integer>
-				<key>relatedAppsMode</key>
-				<integer>0</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.trigger.hotkey</string>
-			<key>uid</key>
-			<string>8D669A41-E6BD-402D-82CF-16D7788A3E14</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>autopaste</key>
-				<false/>
-				<key>clipboardtext</key>
-				<string>{query}</string>
-				<key>ignoredynamicplaceholders</key>
-				<false/>
-				<key>transient</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.output.clipboard</string>
-			<key>uid</key>
-			<string>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</string>
-			<key>version</key>
-			<integer>3</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>alfredfiltersresults</key>
-				<false/>
-				<key>alfredfiltersresultsmatchmode</key>
-				<integer>0</integer>
-				<key>argumenttreatemptyqueryasnil</key>
-				<false/>
-				<key>argumenttrimmode</key>
-				<integer>0</integer>
-				<key>argumenttype</key>
-				<integer>1</integer>
-				<key>escaping</key>
-				<integer>102</integer>
-				<key>queuedelaycustom</key>
-				<integer>3</integer>
-				<key>queuedelayimmediatelyinitially</key>
-				<true/>
-				<key>queuedelaymode</key>
-				<integer>0</integer>
-				<key>queuemode</key>
-				<integer>1</integer>
-				<key>runningsubtext</key>
-				<string>Loading results...</string>
-				<key>script</key>
-				<string>query=$*
-xattr -rd com.apple.quarantine ./alfred-emoji-picker &gt;/dev/null 2&gt;&amp;1 || true
-./alfred-emoji-picker "$query"</string>
-				<key>scriptargtype</key>
-				<integer>1</integer>
-				<key>scriptfile</key>
-				<string></string>
-				<key>subtext</key>
-				<string></string>
-				<key>title</key>
-				<string>Search emoji</string>
-				<key>type</key>
-				<integer>0</integer>
-				<key>withspace</key>
-				<false/>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.input.scriptfilter</string>
-			<key>uid</key>
-			<string>D8F2C967-FA1A-4457-8373-998014ABC3A0</string>
-			<key>version</key>
-			<integer>3</integer>
-		</dict>
 	</array>
 	<key>readme</key>
-	<string></string>
+	<string># Emoji Picker Workflow
+
+Search and insert emoji from Alfred.
+
+## How to use
+
+- Trigger the workflow with your Alfred hotkey.
+- Or type `emoji` in Alfred to open the keyword-based search.
+- Start typing to search for an emoji by name, slug, keyword, or category.
+- Press `Enter` to paste the selected emoji into the frontmost app.
+- Use the copy modifier in the workflow to copy the selected emoji without pasting.
+
+## Frequently used emoji
+
+- Open the workflow with an empty query to see your frequently used emoji.
+- Frequent emoji are ordered by usage count.
+- The number of items shown is controlled by the `Frequent Emoji Limit` workflow setting.
+
+## Reset history
+
+- Type `reset` to show the `Reset frequent emoji` action.
+- Select it to clear the stored frequent emoji history.
+
+## Workflow settings
+
+- `Frequent Emoji Limit`
+  Controls how many frequent emoji are shown for an empty query.
+  Set it to `0` to disable the frequent emoji list.
+
+## Notes
+
+- Emoji usage history is stored in Alfred's workflow data directory.
+- The workflow supports both paste and copy-only flows.</string>
 	<key>uidata</key>
 	<dict>
-		<key>2D22B761-F834-4061-8D65-4F6B2A0E2365</key>
+		<key>3AF7AC2A-A976-48BF-BC47-85FFC9489A93</key>
 		<dict>
+			<key>note</key>
+			<string>Record</string>
 			<key>xpos</key>
-			<real>975</real>
+			<real>575</real>
 			<key>ypos</key>
-			<real>95</real>
+			<real>400</real>
 		</dict>
 		<key>5514CC1D-FA62-4C53-ADC8-0A7E47EABE32</key>
 		<dict>
 			<key>note</key>
 			<string>Auto Paste</string>
 			<key>xpos</key>
-			<real>455</real>
+			<real>745</real>
 			<key>ypos</key>
-			<real>95</real>
+			<real>75</real>
 		</dict>
 		<key>715587DB-6FBB-4B61-A1E1-5DEC6AE8D9DE</key>
 		<dict>
 			<key>note</key>
 			<string>Restore clipboard</string>
 			<key>xpos</key>
-			<real>760</real>
+			<real>1055</real>
 			<key>ypos</key>
-			<real>95</real>
+			<real>75</real>
 		</dict>
 		<key>753EE7F7-6A84-4B07-9C48-1B53B2DBD393</key>
 		<dict>
 			<key>note</key>
 			<string>Wait for previous action to finish pasting</string>
 			<key>xpos</key>
-			<real>650</real>
+			<real>940</real>
 			<key>ypos</key>
-			<real>125</real>
+			<real>105</real>
+		</dict>
+		<key>775BB19D-DB24-45D0-8B65-72BE256BE916</key>
+		<dict>
+			<key>note</key>
+			<string>Reset or continue</string>
+			<key>xpos</key>
+			<real>390</real>
+			<key>ypos</key>
+			<real>175</real>
 		</dict>
 		<key>85D92F9D-5FB7-43BB-972E-AA37378048E7</key>
 		<dict>
 			<key>xpos</key>
-			<real>230</real>
+			<real>190</real>
 			<key>ypos</key>
-			<real>95</real>
+			<real>235</real>
 		</dict>
 		<key>8D669A41-E6BD-402D-82CF-16D7788A3E14</key>
 		<dict>
 			<key>xpos</key>
 			<real>30</real>
 			<key>ypos</key>
-			<real>320</real>
+			<real>235</real>
 		</dict>
 		<key>8E260531-B940-414D-8222-8F44CC4B8419</key>
 		<dict>
 			<key>note</key>
 			<string>Auto Update - remove to disable</string>
 			<key>xpos</key>
-			<real>975</real>
+			<real>1055</real>
 			<key>ypos</key>
-			<real>320</real>
+			<real>400</real>
 		</dict>
 		<key>982E3FBB-2F4C-4046-A324-A7BF07EDCFB9</key>
 		<dict>
 			<key>note</key>
-			<string>Only copy to clipboard (default)</string>
+			<string>Only copy to clipboard</string>
 			<key>xpos</key>
-			<real>610</real>
+			<real>745</real>
 			<key>ypos</key>
-			<real>320</real>
+			<real>400</real>
 		</dict>
-		<key>D8F2C967-FA1A-4457-8373-998014ABC3A0</key>
+		<key>AA873DB5-AD67-4276-AB8B-B7EF039B0D8B</key>
 		<dict>
+			<key>note</key>
+			<string>Reset or continue</string>
 			<key>xpos</key>
-			<real>230</real>
+			<real>390</real>
 			<key>ypos</key>
-			<real>320</real>
+			<real>335</real>
+		</dict>
+		<key>B595CA76-8AE4-4B04-937A-6E3F9F77B39C</key>
+		<dict>
+			<key>note</key>
+			<string>Reset frequent emoji</string>
+			<key>xpos</key>
+			<real>575</real>
+			<key>ypos</key>
+			<real>235</real>
+		</dict>
+		<key>B9B62968-2D5A-448F-AFA4-55699A19A300</key>
+		<dict>
+			<key>note</key>
+			<string>Record</string>
+			<key>xpos</key>
+			<real>575</real>
+			<key>ypos</key>
+			<real>75</real>
 		</dict>
 	</dict>
 	<key>userconfigurationconfig</key>
@@ -530,7 +698,7 @@ xattr -rd com.apple.quarantine ./alfred-emoji-picker &gt;/dev/null 2&gt;&amp;1 |
 			<key>config</key>
 			<dict>
 				<key>defaultvalue</key>
-				<integer>20</integer>
+				<integer>10</integer>
 				<key>markercount</key>
 				<integer>11</integer>
 				<key>maxvalue</key>

--- a/main.go
+++ b/main.go
@@ -35,9 +35,12 @@ func run() {
 	}
 
 	query := os.Args[1]
-	results := search(query)
 	showUsageCount := query == ""
-	stats := usageStats()
+	stats := usage.Stats{}
+	if showUsageCount {
+		stats = usageStats()
+	}
+	results := search(query, stats)
 
 	for _, result := range results {
 		isResetItem := result.Char == "__reset_frequent__"
@@ -81,14 +84,8 @@ func main() {
 	wf.Run(run)
 }
 
-func search(query string) []*turtle.Emoji {
+func search(query string, stats usage.Stats) []*turtle.Emoji {
 	if query == "" {
-		stats, err := usage.Load()
-		if err != nil {
-			log.Printf("load emoji usage stats: %v", err)
-			return []*turtle.Emoji{}
-		}
-
 		return frequentResults(stats)
 	}
 

--- a/main.go
+++ b/main.go
@@ -29,22 +29,33 @@ func run() {
 		return
 	}
 
+	if os.Args[1] == "--reset-frequent" {
+		resetFrequent()
+		return
+	}
+
 	query := os.Args[1]
 	results := search(query)
 	showUsageCount := query == ""
 	stats := usageStats()
 
 	for _, result := range results {
+		isResetItem := result.Char == "__reset_frequent__"
+
 		subtitle := fmt.Sprintf("Input \"%s\" (%s) into foremost application", result.Char, result.Slug)
-		if showUsageCount {
+		if showUsageCount && !isResetItem {
 			subtitle = fmt.Sprintf("%s · Used %d times", subtitle, stats.Count(result.Char))
 		}
 
 		item := wf.NewItem(result.Name).
-			Subtitle(subtitle).
 			Arg(result.Char).
-			Icon(&aw.Icon{Value: fmt.Sprintf("emojis/%s.png", result.Slug)}).
 			Valid(true)
+
+		if !isResetItem {
+			item.Subtitle(subtitle)
+		}
+
+		item.Icon(&aw.Icon{Value: fmt.Sprintf("emojis/%s.png", result.Slug)})
 
 		if !showUsageCount {
 			item.UID(result.Char)
@@ -135,7 +146,17 @@ func search(query string) []*turtle.Emoji {
 		categoryPrefixMatches,
 	}
 
-	return lo.Uniq(lo.Flatten(results))
+	consolidated := lo.Uniq(lo.Flatten(results))
+	if shouldOfferResetFrequent(query) {
+		resetItem := &turtle.Emoji{
+			Name: "Reset frequent emoji",
+			Slug: "wastebasket",
+			Char: "__reset_frequent__",
+		}
+		consolidated = append([]*turtle.Emoji{resetItem}, consolidated...)
+	}
+
+	return consolidated
 }
 
 func recordSelection() {
@@ -144,6 +165,12 @@ func recordSelection() {
 	}
 
 	if err := usage.Increment(os.Args[2]); err != nil {
+		wf.FatalError(err)
+	}
+}
+
+func resetFrequent() {
+	if err := usage.Reset(); err != nil {
 		wf.FatalError(err)
 	}
 }
@@ -195,6 +222,11 @@ func frequentEmojiLimit() int {
 	}
 
 	return limit
+}
+
+func shouldOfferResetFrequent(query string) bool {
+	query = strings.TrimSpace(strings.ToLower(query))
+	return query != "" && strings.HasPrefix(query, "reset")
 }
 
 func emojiByUsageKey(emojiChar string) *turtle.Emoji {

--- a/main.go
+++ b/main.go
@@ -1,46 +1,84 @@
 package main
 
 import (
+	"cmp"
 	"fmt"
+	"log"
 	"os"
+	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/deanishe/awgo"
 	"github.com/devnoname120/alfred-emoji-picker/scoring"
+	"github.com/devnoname120/alfred-emoji-picker/usage"
 	"github.com/devnoname120/turtle"
 	"github.com/samber/lo"
 )
 
 var wf *aw.Workflow
 
-func init() {
-	wf = aw.New()
-}
-
 func run() {
+	if len(os.Args) < 2 {
+		wf.Fatal("missing query argument")
+	}
+
+	if os.Args[1] == "--record" {
+		recordSelection()
+		return
+	}
+
 	query := os.Args[1]
 	results := search(query)
+	showUsageCount := query == ""
+	stats := usageStats()
 
 	for _, result := range results {
-		wf.NewItem(result.Name).
-			Subtitle(fmt.Sprintf("Input \"%s\" (%s) into foremost application", result.Char, result.Slug)).
+		subtitle := fmt.Sprintf("Input \"%s\" (%s) into foremost application", result.Char, result.Slug)
+		if showUsageCount {
+			subtitle = fmt.Sprintf("%s · Used %d times", subtitle, stats.Count(result.Char))
+		}
+
+		item := wf.NewItem(result.Name).
+			Subtitle(subtitle).
 			Arg(result.Char).
 			Icon(&aw.Icon{Value: fmt.Sprintf("emojis/%s.png", result.Slug)}).
 			Valid(true)
+
+		if !showUsageCount {
+			item.UID(result.Char)
+		}
 	}
 
 	wf.WarnEmpty("No matching emojis", "Try a different query?")
 	wf.SendFeedback()
 }
 
+func usageStats() usage.Stats {
+	stats, err := usage.Load()
+	if err != nil {
+		log.Printf("load emoji usage stats for subtitle: %v", err)
+		return usage.Stats{}
+	}
+
+	return stats
+}
+
 func main() {
+	wf = aw.New()
 	wf.Run(run)
 }
 
 func search(query string) []*turtle.Emoji {
 	if query == "" {
-		return make([]*turtle.Emoji, 0)
+		stats, err := usage.Load()
+		if err != nil {
+			log.Printf("load emoji usage stats: %v", err)
+			return []*turtle.Emoji{}
+		}
+
+		return frequentResults(stats)
 	}
 
 	nameSlugExactMatches := turtle.Filter(func(e *turtle.Emoji) bool {
@@ -97,6 +135,90 @@ func search(query string) []*turtle.Emoji {
 		categoryPrefixMatches,
 	}
 
-	consolidated := lo.Uniq(lo.Flatten(results))
-	return consolidated
+	return lo.Uniq(lo.Flatten(results))
+}
+
+func recordSelection() {
+	if len(os.Args) < 3 {
+		wf.Fatal("missing emoji argument for record command")
+	}
+
+	if err := usage.Increment(os.Args[2]); err != nil {
+		wf.FatalError(err)
+	}
+}
+
+func frequentResults(stats usage.Stats) []*turtle.Emoji {
+	limit := frequentEmojiLimit()
+	if limit <= 0 || len(stats) == 0 {
+		return []*turtle.Emoji{}
+	}
+
+	results := make([]*turtle.Emoji, 0, len(stats))
+	for emojiChar, count := range stats {
+		if count <= 0 {
+			continue
+		}
+
+		emoji := emojiByUsageKey(emojiChar)
+		if emoji == nil {
+			continue
+		}
+
+		results = append(results, emoji)
+	}
+
+	sortFrequentByUsage(results, stats)
+	if len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results
+}
+
+func frequentEmojiLimit() int {
+	const defaultLimit = 20
+
+	raw := strings.TrimSpace(os.Getenv("frequent_emoji_limit"))
+	if raw == "" {
+		return defaultLimit
+	}
+
+	limit, err := strconv.Atoi(raw)
+	if err != nil {
+		log.Printf("invalid frequent_emoji_limit %q, using default %d", raw, defaultLimit)
+		return defaultLimit
+	}
+
+	if limit < 0 {
+		return 0
+	}
+
+	return limit
+}
+
+func emojiByUsageKey(emojiChar string) *turtle.Emoji {
+	for _, emoji := range turtle.EmojisByChar {
+		if usage.NormalizeEmoji(emoji.Char) == emojiChar {
+			return emoji
+		}
+	}
+
+	return nil
+}
+
+func sortFrequentByUsage(emojis []*turtle.Emoji, stats usage.Stats) {
+	slices.SortStableFunc(emojis, func(left, right *turtle.Emoji) int {
+		usageLeft := stats.Count(left.Char)
+		usageRight := stats.Count(right.Char)
+		if usageLeft != usageRight {
+			return cmp.Compare(usageRight, usageLeft)
+		}
+
+		if left.Name != right.Name {
+			return cmp.Compare(left.Name, right.Name)
+		}
+
+		return cmp.Compare(left.Char, right.Char)
+	})
 }

--- a/main_test.go
+++ b/main_test.go
@@ -67,3 +67,27 @@ func TestSearchKeepsExactKeywordBeforePrefixKeyword(t *testing.T) {
 		t.Fatalf("expected exact keyword match before prefix keyword match, got cool=%d sunglasses=%d", coolButtonIndex, sunglassesIndex)
 	}
 }
+
+func TestSearchOffersResetFrequentFirst(t *testing.T) {
+	results := search("reset")
+
+	if len(results) == 0 {
+		t.Fatalf("expected reset item in results")
+	}
+
+	if results[0].Char != "__reset_frequent__" {
+		t.Fatalf("expected reset item first, got %q", results[0].Char)
+	}
+}
+
+func TestSearchOffersResetFrequentForLongerResetQuery(t *testing.T) {
+	results := search("reset frequent")
+
+	if len(results) == 0 {
+		t.Fatalf("expected reset item in results")
+	}
+
+	if results[0].Char != "__reset_frequent__" {
+		t.Fatalf("expected reset item first, got %q", results[0].Char)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/devnoname120/alfred-emoji-picker/usage"
+	"github.com/devnoname120/turtle"
+)
+
+func TestFrequentResultsResolvesNormalizedUsageKey(t *testing.T) {
+	t.Setenv("frequent_emoji_limit", "10")
+
+	results := frequentResults(usage.Stats{
+		usage.NormalizeEmoji("🖐️"): 2,
+	})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 frequent result, got %d", len(results))
+	}
+
+	if results[0].Char != "🖐️" {
+		t.Fatalf("expected emoji with variation selector, got %q", results[0].Char)
+	}
+}
+
+func TestFrequentResultsSortByUsageDescending(t *testing.T) {
+	t.Setenv("frequent_emoji_limit", "10")
+
+	results := frequentResults(usage.Stats{
+		usage.NormalizeEmoji("🕶️"): 4,
+		usage.NormalizeEmoji("☀️"): 2,
+		usage.NormalizeEmoji("🆒"):  1,
+	})
+
+	if len(results) != 3 {
+		t.Fatalf("expected 3 frequent results, got %d", len(results))
+	}
+
+	got := []string{results[0].Char, results[1].Char, results[2].Char}
+	want := []string{"🕶️", "☀️", "🆒"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected order %v, got %v", want, got)
+		}
+	}
+}
+
+func TestSearchKeepsExactKeywordBeforePrefixKeyword(t *testing.T) {
+	results := search("cool")
+
+	var coolButtonIndex = -1
+	var sunglassesIndex = -1
+	for i, result := range results {
+		switch result.Char {
+		case turtle.EmojisByChar["🆒"].Char:
+			coolButtonIndex = i
+		case turtle.EmojisByChar["🕶️"].Char:
+			sunglassesIndex = i
+		}
+	}
+
+	if coolButtonIndex == -1 || sunglassesIndex == -1 {
+		t.Fatalf("expected both cool button and sunglasses in results, got cool=%d sunglasses=%d", coolButtonIndex, sunglassesIndex)
+	}
+
+	if coolButtonIndex > sunglassesIndex {
+		t.Fatalf("expected exact keyword match before prefix keyword match, got cool=%d sunglasses=%d", coolButtonIndex, sunglassesIndex)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -46,7 +46,7 @@ func TestFrequentResultsSortByUsageDescending(t *testing.T) {
 }
 
 func TestSearchKeepsExactKeywordBeforePrefixKeyword(t *testing.T) {
-	results := search("cool")
+	results := search("cool", nil)
 
 	var coolButtonIndex = -1
 	var sunglassesIndex = -1
@@ -69,7 +69,7 @@ func TestSearchKeepsExactKeywordBeforePrefixKeyword(t *testing.T) {
 }
 
 func TestSearchOffersResetFrequentFirst(t *testing.T) {
-	results := search("reset")
+	results := search("reset", nil)
 
 	if len(results) == 0 {
 		t.Fatalf("expected reset item in results")
@@ -81,7 +81,7 @@ func TestSearchOffersResetFrequentFirst(t *testing.T) {
 }
 
 func TestSearchOffersResetFrequentForLongerResetQuery(t *testing.T) {
-	results := search("reset frequent")
+	results := search("reset frequent", nil)
 
 	if len(results) == 0 {
 		t.Fatalf("expected reset item in results")

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -62,6 +62,19 @@ func Save(stats Stats) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
+func Reset() error {
+	path, err := statsFilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	return nil
+}
+
 func (s Stats) Count(emojiChar string) int {
 	if s == nil {
 		return 0

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -1,0 +1,83 @@
+package usage
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const statsFileName = "emoji-usage.json"
+
+type Stats map[string]int
+
+func Load() (Stats, error) {
+	path, err := statsFilePath()
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return Stats{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	stats := Stats{}
+	if err := json.Unmarshal(data, &stats); err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func Increment(emojiChar string) error {
+	stats, err := Load()
+	if err != nil {
+		return err
+	}
+
+	stats[NormalizeEmoji(emojiChar)]++
+	return Save(stats)
+}
+
+func Save(stats Stats) error {
+	path, err := statsFilePath()
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(stats, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}
+
+func (s Stats) Count(emojiChar string) int {
+	if s == nil {
+		return 0
+	}
+
+	return s[NormalizeEmoji(emojiChar)]
+}
+
+func statsFilePath() (string, error) {
+	dataDir := os.Getenv("alfred_workflow_data")
+	if dataDir == "" {
+		return "", errors.New("alfred_workflow_data is not set")
+	}
+	return filepath.Join(dataDir, statsFileName), nil
+}
+
+func NormalizeEmoji(e string) string {
+	return strings.ReplaceAll(e, "\uFE0F", "")
+}

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -1,0 +1,57 @@
+package usage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIncrementNormalizesEquivalentEmojiVariants(t *testing.T) {
+	t.Setenv("alfred_workflow_data", t.TempDir())
+
+	if err := Increment("🖐️"); err != nil {
+		t.Fatalf("increment variant with VS16: %v", err)
+	}
+	if err := Increment("🖐"); err != nil {
+		t.Fatalf("increment variant without VS16: %v", err)
+	}
+
+	stats, err := Load()
+	if err != nil {
+		t.Fatalf("load stats: %v", err)
+	}
+
+	if got := stats.Count("🖐️"); got != 2 {
+		t.Fatalf("expected normalized count 2, got %d", got)
+	}
+
+	if got := stats[NormalizeEmoji("🖐️")]; got != 2 {
+		t.Fatalf("expected stored normalized count 2, got %d", got)
+	}
+}
+
+func TestLoadMissingFileReturnsEmptyStats(t *testing.T) {
+	t.Setenv("alfred_workflow_data", t.TempDir())
+
+	stats, err := Load()
+	if err != nil {
+		t.Fatalf("load stats: %v", err)
+	}
+
+	if len(stats) != 0 {
+		t.Fatalf("expected empty stats, got %d entries", len(stats))
+	}
+}
+
+func TestSaveCreatesExpectedFile(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("alfred_workflow_data", dataDir)
+
+	if err := Save(Stats{"🙂": 3}); err != nil {
+		t.Fatalf("save stats: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dataDir, statsFileName)); err != nil {
+		t.Fatalf("stat saved file: %v", err)
+	}
+}

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -1,6 +1,7 @@
 package usage
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,5 +54,22 @@ func TestSaveCreatesExpectedFile(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(dataDir, statsFileName)); err != nil {
 		t.Fatalf("stat saved file: %v", err)
+	}
+}
+
+func TestResetRemovesStatsFile(t *testing.T) {
+	dataDir := t.TempDir()
+	t.Setenv("alfred_workflow_data", dataDir)
+
+	if err := Save(Stats{"🙂": 3}); err != nil {
+		t.Fatalf("save stats: %v", err)
+	}
+
+	if err := Reset(); err != nil {
+		t.Fatalf("reset stats: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dataDir, statsFileName)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stats file to be removed, got err=%v", err)
 	}
 }


### PR DESCRIPTION
##  What’s new

- Added a frequently used emoji list for empty queries.
- Frequent emoji are ordered by usage count.
- Added a workflow setting to control how many frequent emoji are shown.
- Added a reset action for frequent emoji history.
- Added a CLI command to clear stored frequent emoji history.
- Versioned the workflow config by adding info.plist to the repository.
- Added tests for frequent emoji behavior and reset-related logic.

## Workflow changes

- Frequent Emoji Limit setting controls the empty-query frequent list.
- Typing reset shows a Reset frequent emoji action.
- Selecting the reset action clears the stored frequent emoji history.
- Frequent emoji history is updated from both paste and copy-only flows.
- Added readme content for the workflow configuration UI (About this Workflow).

## Implementation notes:

- `frequent_emoji_limit=0` disables the frequent list.
- Reset action is guarded in the workflow so the sentinel value is never copied to clipboard.